### PR TITLE
Only first volume found worked correctly.

### DIFF
--- a/checks/qnap_volumes
+++ b/checks/qnap_volumes
@@ -35,15 +35,15 @@ def inventory_qnap_volumes(info):
 
 def check_qnap_volumes(item, _no_params, info):
     for volid, volstate, fstype, arrayinfo in info:
-        arrayinfo = arrayinfo.lstrip("[")
-        arrayinfo = arrayinfo.rstrip("]")
-        infotext = " Volume state is %s, Filesystem type is %s, %s" % (volstate, fstype, arrayinfo)
         if volid == item:
+            arrayinfo = arrayinfo.lstrip("[")
+            arrayinfo = arrayinfo.rstrip("]")
+            infotext = " Volume state is %s, Filesystem type is %s, %s" % (volstate, fstype, arrayinfo)
             if volstate == "Ready":
                 return (0, "OK - " + infotext )
             elif volstate == "Rebuilding...":
                 return (1, "Warning - " + infotext )
-        else:
+            else:
                 return (2, "Critical - " + infotext)
     return (3, "UNKNOWN - Volume")
 


### PR DESCRIPTION
If more than one volume was existing only the first one was shown correctly. All other volumes get critical state and the info text from first volume.