### PR TITLE
Update check_parameters_qnap_temp.py

### DIFF
--- a/web/check_parameters_qnap_temp.py
+++ b/web/check_parameters_qnap_temp.py
@@ -3,7 +3,7 @@ subgroup_applications = _("Temperature, Humidity, Electrical Parameters, etc.")
 register_check_parameters(
     subgroup_applications,
     "qnap_temp",
-    _("Parameters for QNAP Fans"),
+    _("Parameters for QNAP Temperature"),
     Dictionary(
         elements = [
             ('cpuTemp', Tuple(


### PR DESCRIPTION
Line 6, "Parameters for QNAP Temperature" instead of "Parameters for QNAP Fans"
Because "Parameters for QNAP Fans" is also used in "check_parameters_qnap_fans.py". Which results in two different rulesets with the same name.